### PR TITLE
fix: remove event listeners correctly

### DIFF
--- a/roverdriverweb/src/Rover.js
+++ b/roverdriverweb/src/Rover.js
@@ -58,12 +58,15 @@ class Rover {
   }
 
   writeRX(data) {
-    // console.log(data);
     return this.device.gatt.getPrimaryService("6e400001-b5a3-f393-e0a9-e50e24dcca9e")
       .then(service => service.getCharacteristic("6e400002-b5a3-f393-e0a9-e50e24dcca9e"))
       .then(characteristic => characteristic.writeValue(data))
+      .then(() => new Promise(r => setTimeout(() => {
+        r();
+    }, 75)))
       .catch(e => {
         if (e.name === "NetworkError") {
+          // Consider raising a more immediate alert here
           console.log("Known: " + e);
         } else {
           console.log("Unknown: " + e);

--- a/roverdriverweb/src/TabSettings.js
+++ b/roverdriverweb/src/TabSettings.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Box, CheckBox } from "grommet";
+import { Box, CheckBox, Text } from "grommet";
 import { StyledCard } from "./CommonUI";
 import ls from 'local-storage';
 
@@ -45,6 +45,11 @@ class TabSettings extends React.Component {
                         toggle
                     />
                 </Box>
+            </StyledCard>
+            <StyledCard wide title="App Info">
+                <Text>
+                    Built at $build_date$
+                </Text>
             </StyledCard>
         </Box>;
     }


### PR DESCRIPTION
Redefined anonymous functions passed to event listeners as class
variables using arrow notation so removing event listeners work
correctly. This should reduce errors with disconnecting/connecting from
the rover repeatedly. As well, when the page is invisible, the TX
listener handler is removed from the TX characteristic, hopefully
preventing a buildup of notifications and lag if the rover is connected
but the tab is in the background for a long time (to be tested on mobile
after this build/deploy completes.)

Finally, this commit introduces a 75ms delay between sending messages to
the RX characteristic. This allows the rover time to process the last
sent message if messages are sent in rapid succession (ie. keyboard
control.)